### PR TITLE
Fix twitter share link

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -7,8 +7,14 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Flexboxのスタイルが生成できます。"
     />
+    <meta property="og:description" content="Flexboxのスタイルが生成できます。" />
+    <meta property="og:image" content="%PUBLIC_URL%/logo512.png" />
+    <meta property="og:title" content="Flex Generator" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="%PUBLIC_URL%/" />
+    <meta name="twitter:card" content="summary" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Flex Generator</title>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -10,10 +10,10 @@
       content="Flexboxのスタイルが生成できます。"
     />
     <meta property="og:description" content="Flexboxのスタイルが生成できます。" />
-    <meta property="og:image" content="%PUBLIC_URL%/logo512.png" />
+    <meta property="og:image" content="https://yota-k.github.io%PUBLIC_URL%/logo512.png" />
     <meta property="og:title" content="Flex Generator" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="%PUBLIC_URL%/" />
+    <meta property="og:url" content="https://yota-k.github.io%PUBLIC_URL%/" />
     <meta name="twitter:card" content="summary" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />

--- a/app/src/components/SocialIcons.js
+++ b/app/src/components/SocialIcons.js
@@ -5,7 +5,7 @@ const SocialIcons = () => {
     return (
         <>
             <SocialIcon
-                url="https://twitter.com/intent/tweet?url=https://yota-k.github.io/flex-generator/hashtags=FlexGenerator"
+                url="https://twitter.com/intent/tweet?url=https://yota-k.github.io/flex-generator/"
                 network="twitter"
             />
         </>


### PR DESCRIPTION
It seems the Twitter share link is broken, so fixed it!

And set up OGP and Twitter Card in order to improve the appearance when shared the link. 
https://cards-dev.twitter.com/validator

![Screenshot from 2020-05-17 19-51-45](https://user-images.githubusercontent.com/7702653/82143055-024a1e80-987c-11ea-956a-24a558845f65.png)

Some OGP properties (og:image, etc) are not set up correctly, these need to be fixed before publishing to gh-pages branch. 