### PR TITLE
Remove apk from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 FROM node:10.13-alpine
 
-RUN apk update
-
-RUN apk add nodejs && \
-    apk add npm && \
-    apk add git
-
 RUN npm install -g create-react-app
 
 ENV NODE_PATH /usr/local/lib/node_modules


### PR DESCRIPTION
It seems that apk add command in Dockerfile is not needed for node:10.13-alpine because Node.js and npm are pre-installed. 
Thank you for maintaining this repository :)